### PR TITLE
Fix depth of field. Add transparent scenes in EC.

### DIFF
--- a/src/Core_Screencap/Renderers/AlphaShot2.cs
+++ b/src/Core_Screencap/Renderers/AlphaShot2.cs
@@ -66,11 +66,29 @@ namespace alphaShot
             Texture2D fullSizeCapture = null;
             int newWidth = ResolutionX * DownscalingRate;
             int newHeight = ResolutionY * DownscalingRate;
+            float orgBlurSize = 0.0f;
 
-            if (Transparent && (InStudio || SceneManager.GetActiveScene().name == "CustomScene"))
+            // Fix depth of field
+            DepthOfField dof = (DepthOfField)Camera.main.gameObject.GetComponent(typeof(DepthOfField));
+            if (dof != null)
+            {
+                orgBlurSize = dof.maxBlurSize;
+                dof.maxBlurSize = newWidth * orgBlurSize / Screen.width;
+            }
+
+            if (Transparent && (InStudio
+                || SceneManager.GetActiveScene().name == "CustomScene"
+                || SceneManager.GetActiveScene().name == "HEditScene"
+                || SceneManager.GetActiveScene().name == "HPlayScene"))
                 fullSizeCapture = CaptureAlpha(newWidth, newHeight);
             else
                 fullSizeCapture = CaptureOpaque(newWidth, newHeight);
+
+            // Recover depth of field
+            if (dof != null)
+            {
+                dof.maxBlurSize = orgBlurSize;
+            }
 
             if (DownscalingRate > 1)
                 return LanczosTex(fullSizeCapture, ResolutionX, ResolutionY);

--- a/src/Core_Screencap/Renderers/AlphaShot2.cs
+++ b/src/Core_Screencap/Renderers/AlphaShot2.cs
@@ -66,29 +66,11 @@ namespace alphaShot
             Texture2D fullSizeCapture = null;
             int newWidth = ResolutionX * DownscalingRate;
             int newHeight = ResolutionY * DownscalingRate;
-            float orgBlurSize = 0.0f;
 
-            // Fix depth of field
-            DepthOfField dof = (DepthOfField)Camera.main.gameObject.GetComponent(typeof(DepthOfField));
-            if (dof != null)
-            {
-                orgBlurSize = dof.maxBlurSize;
-                dof.maxBlurSize = newWidth * orgBlurSize / Screen.width;
-            }
-
-            if (Transparent && (InStudio
-                || SceneManager.GetActiveScene().name == "CustomScene"
-                || SceneManager.GetActiveScene().name == "HEditScene"
-                || SceneManager.GetActiveScene().name == "HPlayScene"))
+            if (Transparent && (InStudio || SceneManager.GetActiveScene().name == "CustomScene"))
                 fullSizeCapture = CaptureAlpha(newWidth, newHeight);
             else
                 fullSizeCapture = CaptureOpaque(newWidth, newHeight);
-
-            // Recover depth of field
-            if (dof != null)
-            {
-                dof.maxBlurSize = orgBlurSize;
-            }
 
             if (DownscalingRate > 1)
                 return LanczosTex(fullSizeCapture, ResolutionX, ResolutionY);


### PR DESCRIPTION
Two changes were made.
- Reflect depth of field on screenshots.
- Transparent through backgrounds on H editing scene and H playing scene in Emotion Creators.

The previous pull request was made by mistake because I didn't get used to using github. I'm sorry.