### PR TITLE
[PH SliderUnlocker] Fix slider range getting locked to [-1, 2] 

### DIFF
--- a/src/Core_SliderUnlocker/Core.SliderUnlocker.cs
+++ b/src/Core_SliderUnlocker/Core.SliderUnlocker.cs
@@ -32,10 +32,18 @@ namespace SliderUnlocker
         internal static float SliderAbsoluteMax => Math.Max(SliderMax, 5f);
         /// <summary> Minimum value sliders can possibly extend </summary>
         internal static float SliderAbsoluteMin => Math.Min(SliderMin, -5f);
+
+        #if !PH
         /// <summary> Maximum value of sliders when not dynamically unlocked </summary>
         internal static float SliderMax => (Maximum.Value < 100 ? 100 : Maximum.Value) / 100f;
         /// <summary> Minimum value of sliders when not dynamically unlocked </summary>
         internal static float SliderMin => (Minimum.Value > 0 ? 0 : Minimum.Value) / 100f;
+        #else 
+        /// <summary> Maximum value of sliders when not dynamically unlocked </summary>
+        internal static float SliderMax => (Maximum.Value < 100 ? 100 : Maximum.Value);
+        /// <summary> Minimum value of sliders when not dynamically unlocked </summary>
+        internal static float SliderMin => (Minimum.Value > 0 ? 0 : Minimum.Value);
+        #endif
 
         public static ConfigEntry<int> Minimum { get; private set; }
         public static ConfigEntry<int> Maximum { get; private set; }
@@ -249,7 +257,11 @@ namespace SliderUnlocker
         /// </summary>
         private static void UnlockSliderFromInput(Slider _slider, TMP_InputField _inputField, bool defaultRange)
         {
+            #if !PH
             var value = float.TryParse(_inputField.text, out var num) ? num / 100 : 0;
+            #else
+            var value = float.TryParse(_inputField.text, out var num) ? num : 0;
+            #endif
 
             if (value > SliderAbsoluteMax)
             {

--- a/src/PH_SliderUnlocker/PH.SliderUnlocker.cs
+++ b/src/PH_SliderUnlocker/PH.SliderUnlocker.cs
@@ -30,7 +30,6 @@ namespace SliderUnlocker
             {
                 CheckableSlider slider = Traverse.Create(x).Field("slider").GetValue() as CheckableSlider;
                 InputField inputField = Traverse.Create(x).Field("inputField").GetValue() as InputField;
-                Button defButton = Traverse.Create(x).Field("defButton").GetValue() as Button;
 
                 slider.minValue = SliderMin * 100;
                 slider.maxValue = SliderMax * 100;
@@ -52,9 +51,6 @@ namespace SliderUnlocker
 
                 //When the user types a value, unlock the sliders to accomodate
                 inputField.onEndEdit.AddListener(_ => UnlockSliderFromInput(slider, inputField));
-
-                //When the button is clicked set a flag used by InputFieldOnValueChanged
-                defButton.onClick.AddListener(() => buttonClicked = true);
             }
         }
         /// <summary>

--- a/src/PH_SliderUnlocker/PH.SliderUnlocker.cs
+++ b/src/PH_SliderUnlocker/PH.SliderUnlocker.cs
@@ -30,27 +30,20 @@ namespace SliderUnlocker
             {
                 CheckableSlider slider = Traverse.Create(x).Field("slider").GetValue() as CheckableSlider;
                 InputField inputField = Traverse.Create(x).Field("inputField").GetValue() as InputField;
+                Button defButton = Traverse.Create(x).Field("defButton").GetValue() as Button;
 
-                slider.minValue = SliderMin * 100;
-                slider.maxValue = SliderMax * 100;
+                slider.minValue = SliderMin;
+                slider.maxValue = SliderMax;
 
                 bool buttonClicked = false;
 
                 inputField.characterLimit = 4;
 
-                //After reset button click, reset the slider unlock state
-                inputField.onValueChanged.AddListener(
-                    _ =>
-                    {
-                        if (buttonClicked)
-                        {
-                            buttonClicked = false;
-                            UnlockSliderFromInput(slider, inputField);
-                        }
-                    });
-
                 //When the user types a value, unlock the sliders to accomodate
                 inputField.onEndEdit.AddListener(_ => UnlockSliderFromInput(slider, inputField));
+                
+                //When the button is clicked set a flag used by InputFieldOnValueChanged
+                defButton.onClick.AddListener(() => UnlockSliderFromInput(slider, inputField));
             }
         }
         /// <summary>
@@ -61,8 +54,8 @@ namespace SliderUnlocker
             foreach (var x in FindObjectsOfType<InputSliderUI>())
             {
                 CheckableSlider slider = Traverse.Create(x).Field("slider").GetValue() as CheckableSlider;
-                slider.maxValue = SliderAbsoluteMax;
-                slider.minValue = SliderAbsoluteMin;
+                slider.maxValue = SliderAbsoluteMax / 100;
+                slider.minValue = SliderAbsoluteMin / 100;
             }
         }
         /// <summary>


### PR DESCRIPTION
**Issues:** 
* Clicking the default button and trying to move the slider will cause it to get stuck at [-1, 2] range.

~~**Comments:**~~
~~* No idea why that code was there, would be nice to know if it was important for anything because I didn't notice any issues caused by removing it.~~