### PR TITLE
Sideloader - Body Details not being managed by Sideloader

### DIFF
--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.StructReference.AI.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.StructReference.AI.cs
@@ -104,7 +104,7 @@ namespace Sideloader.AutoResolver
 
             var baseProperties = new List<CategoryProperty>
             {
-                new CategoryProperty(CategoryNo.ft_detail_f, "detailId"),
+                new CategoryProperty(CategoryNo.ft_detail_b, "detailId"),
                 new CategoryProperty(CategoryNo.st_nip, "nipId"),
                 new CategoryProperty(CategoryNo.ft_skin_b, "skinId"),
                 new CategoryProperty(CategoryNo.st_underhair, "underhairId"),


### PR DESCRIPTION
Had issues with body details randomly failing to load (especially with Hooh Pogskin 1.2) and reverting to default. Noticed when looking at Sideloader debug logging that the ft_detail_b category items weren't showing up in the logs. Went digging and found this. 

I'm now seeing this load the plugin, save and load from cards and generally work as expected.