### PR TITLE
[AI, HS2] Non-alpha rendered screenshot background fix

### DIFF
--- a/src/AIHS2_Core_Screencap/ScreenshotManager.cs
+++ b/src/AIHS2_Core_Screencap/ScreenshotManager.cs
@@ -415,8 +415,8 @@ namespace Screencap
             var oldRt = cam.targetTexture;
             var oldRtc = Camera.current.targetTexture;
 
-            cam.clearFlags = CameraClearFlags.SolidColor;
-            cam.backgroundColor = alpha ? new Color(0, 0, 0, 0) : Color.black;
+            cam.clearFlags = alpha ? CameraClearFlags.SolidColor : oldCf;
+            cam.backgroundColor = alpha ? new Color(0, 0, 0, 0) : oldBg;
             cam.targetTexture = rt;
 
             cam.Render();


### PR DESCRIPTION
Non-alpha rendered screenshots now able to capture background color and skybox correctly instead of black background in Maker and Studio. This addresses #92 .

This does not fix a bug with background image not being captured correctly in some cases. No noticeable changes in how screenshot manager behaves in main games.