### PR TITLE
Fix Apply ColorCorrector on Scene initialization in KKS

### DIFF
--- a/src/Core_ColorCorrector/Core.ColorCorrector.cs
+++ b/src/Core_ColorCorrector/Core.ColorCorrector.cs
@@ -1,5 +1,7 @@
 ﻿using BepInEx.Configuration;
 using BepisPlugins;
+using System;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityStandardAssets.ImageEffects;
@@ -44,7 +46,14 @@ namespace ColorCorrector
                 _amplifyComponent = Camera.main.gameObject.GetComponent<AmplifyColorEffect>();
                 _bloomComponent = Camera.main.gameObject.GetComponent<BloomAndFlares>();
 
+#if KK || EC
                 SetEffects(SaturationEnabled.Value, BloomStrength.Value);
+#elif KKS
+                StartCoroutine(DelayMethod(() =>
+                {
+                    SetEffects(SaturationEnabled.Value, BloomStrength.Value);
+                }));
+#endif
             }
         }
 
@@ -55,6 +64,11 @@ namespace ColorCorrector
 
             if (_bloomComponent != null)
                 _bloomComponent.bloomIntensity = bloomPower;
+        }
+        private IEnumerator DelayMethod(Action action)
+        {
+            yield return null;
+            action();
         }
 
         private void OnSettingChanged(object sender, System.EventArgs e) => SetEffects(SaturationEnabled.Value, BloomStrength.Value);

--- a/src/Core_ColorCorrector/Core.ColorCorrector.cs
+++ b/src/Core_ColorCorrector/Core.ColorCorrector.cs
@@ -66,6 +66,7 @@ namespace ColorCorrector
             if (_bloomComponent != null)
                 _bloomComponent.bloomIntensity = bloomPower;
         }
+
         private IEnumerator DelayMethod(Action action)
         {
             yield return null;

--- a/src/Core_ColorCorrector/Core.ColorCorrector.cs
+++ b/src/Core_ColorCorrector/Core.ColorCorrector.cs
@@ -26,13 +26,14 @@ namespace ColorCorrector
 #if KK || EC
         private const float DefaultBloomStrength = 1.5f;
 #elif KKS
-        private const float DefaultBloomStrength = 2f;
+        private const float DefaultBloomStrength = 0.5f;
 #endif
+        private const float MaxBloomStrength = 2.0f;
 
         private void Start()
         {
             SaturationEnabled = Config.Bind("Post Processing Settings", "Enable saturation filter", true, new ConfigDescription("Whether default saturation filter will be applied to the game. This setting has no effect in Studio."));
-            BloomStrength = Config.Bind("Post Processing Settings", "Bloom strength", DefaultBloomStrength, new ConfigDescription("Strength of the bloom filter. Not active in Studio, control bloom settings through the in game Scene Effects menu.", new AcceptableValueRange<float>(0f, DefaultBloomStrength)));
+            BloomStrength = Config.Bind("Post Processing Settings", "Bloom strength", DefaultBloomStrength, new ConfigDescription("Strength of the bloom filter. Not active in Studio, control bloom settings through the in game Scene Effects menu.", new AcceptableValueRange<float>(0f, MaxBloomStrength)));
             SaturationEnabled.SettingChanged += OnSettingChanged;
             BloomStrength.SettingChanged += OnSettingChanged;
 


### PR DESCRIPTION
2 Problems Fixed

- Problem
  - Bloom intensity overridden by game on scene initialization, so ColorCorrector configuration does not work
  - DefaultBloomStrength does not match KKS Default value