### PR TITLE
Store author and website alongside the GUID on cards.

### DIFF
--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.Hooks.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.Hooks.cs
@@ -410,7 +410,7 @@ namespace Sideloader.AutoResolver
                     if (__state.FaceData[property.Key.Property] == null) continue;
                     var resolveinfo = TryGetResolutionInfo(property.Value.GetMethod(__instance.custom.face), $"{property.Key.Prefix}.{property.Key.Property}", property.Key.Category, __state.FaceData[property.Key.Property]);
                     if (resolveinfo == null)
-                        ShowGUIDError(__state.FaceData[property.Key.Property]);
+                        ShowGUIDError(__state.FaceData[property.Key.Property], null, null);
                     else
                         faceResolveInfos.Add(resolveinfo);
                 }
@@ -420,7 +420,7 @@ namespace Sideloader.AutoResolver
                     if (__state.MakeupData[property.Key.Property] == null) continue;
                     var resolveinfo = TryGetResolutionInfo(property.Value.GetMethod(__instance.custom.face.makeup), $"{property.Key.Prefix}.{property.Key.Property}", property.Key.Category, __state.MakeupData[property.Key.Property]);
                     if (resolveinfo == null)
-                        ShowGUIDError(__state.MakeupData[property.Key.Property]);
+                        ShowGUIDError(__state.MakeupData[property.Key.Property], null, null);
                     else
                         makeupResolveInfos.Add(resolveinfo);
                 }

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.Hooks.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.Hooks.cs
@@ -410,7 +410,7 @@ namespace Sideloader.AutoResolver
                     if (__state.FaceData[property.Key.Property] == null) continue;
                     var resolveinfo = TryGetResolutionInfo(property.Value.GetMethod(__instance.custom.face), $"{property.Key.Prefix}.{property.Key.Property}", property.Key.Category, __state.FaceData[property.Key.Property]);
                     if (resolveinfo == null)
-                        ShowGUIDError(__state.FaceData[property.Key.Property], null, null);
+                        ShowGUIDError(__state.FaceData[property.Key.Property], null, null, null);
                     else
                         faceResolveInfos.Add(resolveinfo);
                 }
@@ -420,7 +420,7 @@ namespace Sideloader.AutoResolver
                     if (__state.MakeupData[property.Key.Property] == null) continue;
                     var resolveinfo = TryGetResolutionInfo(property.Value.GetMethod(__instance.custom.face.makeup), $"{property.Key.Prefix}.{property.Key.Property}", property.Key.Category, __state.MakeupData[property.Key.Property]);
                     if (resolveinfo == null)
-                        ShowGUIDError(__state.MakeupData[property.Key.Property], null, null);
+                        ShowGUIDError(__state.MakeupData[property.Key.Property], null, null, null);
                     else
                         makeupResolveInfos.Add(resolveinfo);
                 }

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.ResolveInfo.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.ResolveInfo.cs
@@ -52,6 +52,12 @@ namespace Sideloader.AutoResolver
         [Key("Website")]
         public string Website { get; set; }
 
+        /// <summary>
+        /// Display name of the mod as defined in the manifest.xml
+        /// </summary>
+        [Key("Name")]
+        public string Name { get; set; }
+
         internal static ResolveInfo Deserialize(byte[] data) => MessagePackSerializer.Deserialize<ResolveInfo>(data);
 
         internal byte[] Serialize() => MessagePackSerializer.Serialize(this);

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.ResolveInfo.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.ResolveInfo.cs
@@ -40,6 +40,18 @@ namespace Sideloader.AutoResolver
         [Key("CategoryNo")]
         public ChaListDefine.CategoryNo CategoryNo { get; set; }
 
+        /// <summary>
+        /// Author of the mod as defined in the manifest.xml
+        /// </summary>
+        [Key("Author")]
+        public string Author { get; set; }
+
+        /// <summary>
+        /// Website of the mod as defined in the manifest.xml
+        /// </summary>
+        [Key("Website")]
+        public string Website { get; set; }
+
         internal static ResolveInfo Deserialize(byte[] data) => MessagePackSerializer.Deserialize<ResolveInfo>(data);
 
         internal byte[] Serialize() => MessagePackSerializer.Serialize(this);

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
@@ -237,7 +237,7 @@ namespace Sideloader.AutoResolver
                         if (int.TryParse(mainAB, out int x))
                         {
                             //ID found but it conflicts with a vanilla item. Change the ID to avoid conflicts.
-                            ShowGUIDError(extResolve.GUID);
+                            ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website);
                             if (kv.Key.Category.ToString().Contains("ao_") && Sideloader.KeepMissingAccessories.Value && GetNowSceneNames().Any(sceneName => sceneName == "CustomScene"))
                                 kv.Value.SetMethod(structure, 1);
                             else
@@ -252,7 +252,7 @@ namespace Sideloader.AutoResolver
                     else
                     {
                         //ID not found. Change the ID to avoid potential future conflicts.
-                        ShowGUIDError(extResolve.GUID);
+                        ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website);
                         if (kv.Key.Category.ToString().Contains("ao_") && Sideloader.KeepMissingAccessories.Value && GetNowSceneNames().Any(sceneName => sceneName == "CustomScene"))
                             kv.Value.SetMethod(structure, 1);
                         else
@@ -376,7 +376,7 @@ namespace Sideloader.AutoResolver
 
                     var resolveInfo = TryGetResolutionInfo(faceSkinInfo.HeadSlot, ChaListDefine.CategoryNo.fo_head, faceSkinInfo.HeadGUID);
                     if (resolveInfo == null)
-                        ShowGUIDError(faceSkinInfo.HeadGUID);
+                        ShowGUIDError(faceSkinInfo.HeadGUID, null, null);
                     else
                     {
                         if (headID != faceSkinInfo.HeadSlot)
@@ -408,7 +408,7 @@ namespace Sideloader.AutoResolver
 
                     var resolveInfo = TryGetResolutionInfo(faceSkinInfo.HeadSlot, ChaListDefine.CategoryNo.mo_head, faceSkinInfo.HeadGUID);
                     if (resolveInfo == null)
-                        ShowGUIDError(faceSkinInfo.HeadGUID);
+                        ShowGUIDError(faceSkinInfo.HeadGUID, null, null);
                     else
                     {
                         if (headID != faceSkinInfo.HeadSlot)
@@ -479,6 +479,8 @@ namespace Sideloader.AutoResolver
                     {
                         Sideloader.Logger.LogInfo($"ResolveInfo - " +
                                                   $"GUID: {manifest.GUID} " +
+                                                  $"Author: {manifest.Author} " +
+                                                  $"Website: {manifest.Website} " +
                                                   $"Slot: {int.Parse(kv.Value[0])} " +
                                                   $"LocalSlot: {newSlot} " +
                                                   $"Property: Ramp " +
@@ -492,7 +494,9 @@ namespace Sideloader.AutoResolver
                         Slot = int.Parse(kv.Value[0]),
                         LocalSlot = newSlot,
                         Property = "Ramp",
-                        CategoryNo = category
+                        CategoryNo = category,
+                        Author = manifest.Author,
+                        Website = manifest.Website
                     });
                 }
                 else
@@ -504,6 +508,8 @@ namespace Sideloader.AutoResolver
                         {
                             Sideloader.Logger.LogInfo($"ResolveInfo - " +
                                                       $"GUID: {manifest.GUID} " +
+                                                      $"Author: {manifest.Author}" +
+                                                      $"Website: {manifest.Website}" +
                                                       $"Slot: {int.Parse(kv.Value[0])} " +
                                                       $"LocalSlot: {newSlot} " +
                                                       $"Property: {propertyKey} " +
@@ -517,7 +523,9 @@ namespace Sideloader.AutoResolver
                             Slot = int.Parse(kv.Value[0]),
                             LocalSlot = newSlot,
                             Property = propertyKey.ToString(),
-                            CategoryNo = category
+                            CategoryNo = category,
+                            Author = manifest.Author,
+                            Website = manifest.Website
                         };
                     }));
                 }
@@ -546,21 +554,21 @@ namespace Sideloader.AutoResolver
         }
 #endif
 
-        internal static void ShowGUIDError(string guid)
+        internal static void ShowGUIDError(string guid, string author, string website)
         {
             Logging.LogLevel loglevel = Sideloader.MissingModWarning.Value ? Logging.LogLevel.Warning | Logging.LogLevel.Message : Logging.LogLevel.Warning;
 
             if (LoadedResolutionInfo.Any(x => x.GUID == guid))
                 //we have the GUID loaded, so the user has an outdated mod
-                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Outdated mod detected! [{guid}]");
+                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Outdated mod detected! [{guid}]:[By:{author}]:[Site:{website}]");
 #if KK || AI || HS2 || KKS
             else if (LoadedStudioResolutionInfo.Any(x => x.GUID == guid))
                 //we have the GUID loaded, so the user has an outdated mod
-                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Outdated mod detected! [{guid}]");
+                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Outdated mod detected! [{guid}]:[By:{author}]:[Site:{website}]");
 #endif
             else
                 //did not find a match, we don't have the mod
-                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Missing mod detected! [{guid}]");
+                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Missing mod detected! [{guid}]:[By:{author}]:[Site:{website}]");
         }
 
         private static List<string> GetNowSceneNames()

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
@@ -565,22 +565,31 @@ namespace Sideloader.AutoResolver
             if (LoadedResolutionInfo.Any(x => x.GUID == guid))
             {
                 //we have the GUID loaded, so the user has an outdated mod
-                Sideloader.Logger.Log(loglevel, $"Outdated zipmod, some items are missing! - {author} : {(string.IsNullOrEmpty(name) ? guid : name)}");
-                Sideloader.Logger.LogWarning($"[UAR] WARNING! Outdated mod detected! {guid} : {website}");
+                Sideloader.Logger.Log(loglevel, "Outdated zipmod! Some items are missing! - " + 
+                                                (string.IsNullOrEmpty(author) ? "" : author + " : ") + 
+                                                (string.IsNullOrEmpty(name) ? guid : name));
+                                                
+                Sideloader.Logger.LogWarning($"[UAR] WARNING! Outdated mod detected! [{guid}]  {website}");
             }
 #if KK || AI || HS2 || KKS
             else if (LoadedStudioResolutionInfo.Any(x => x.GUID == guid))
             {
                 //we have the GUID loaded, so the user has an outdated mod
-                Sideloader.Logger.Log(loglevel, $"Outdated zipmod, some items are missing! - {author} : {(string.IsNullOrEmpty(name) ? guid : name)}");
-                Sideloader.Logger.LogWarning($"[UAR] WARNING! Outdated mod detected! {guid} : {website}");
+                Sideloader.Logger.Log(loglevel, "Outdated zipmod! Some items are missing! - " + 
+                                                (string.IsNullOrEmpty(author) ? "" : author + " : ") + 
+                                                (string.IsNullOrEmpty(name) ? guid : name));
+                                                
+                Sideloader.Logger.LogWarning($"[UAR] WARNING! Outdated mod detected! [{guid}]  {website}");
             }
 #endif
             else
             {
                 //did not find a match, we don't have the mod
-                Sideloader.Logger.Log(loglevel, $"Missing zipmod, some items are missing! - {author} : {(string.IsNullOrEmpty(name) ? guid : name)}");
-                Sideloader.Logger.LogWarning($"[UAR] WARNING! Missing mod detected! {guid} : {website}");
+                Sideloader.Logger.Log(loglevel, "Missing zipmod! Some items are missing! - " + 
+                                                (string.IsNullOrEmpty(author) ? "" : author + " : ") + 
+                                                (string.IsNullOrEmpty(name) ? guid : name));
+                                                
+                Sideloader.Logger.LogWarning($"[UAR] WARNING! Missing mod detected! [{guid}]  {website}");
             }
         }
 

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
@@ -565,22 +565,22 @@ namespace Sideloader.AutoResolver
             if (LoadedResolutionInfo.Any(x => x.GUID == guid))
             {
                 //we have the GUID loaded, so the user has an outdated mod
-                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Outdated mod detected! {author}:{(string.IsNullOrEmpty(name) ? guid : name)}");
-                Sideloader.Logger.LogWarning($"[UAR] WARNING! {guid}:{website}");
+                Sideloader.Logger.Log(loglevel, $"Outdated zipmod, some items are missing! - {author} : {(string.IsNullOrEmpty(name) ? guid : name)}");
+                Sideloader.Logger.LogWarning($"[UAR] WARNING! Outdated mod detected! {guid} : {website}");
             }
 #if KK || AI || HS2 || KKS
             else if (LoadedStudioResolutionInfo.Any(x => x.GUID == guid))
             {
                 //we have the GUID loaded, so the user has an outdated mod
-                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Outdated mod detected! {author}:{(string.IsNullOrEmpty(name) ? guid : name)}");
-                Sideloader.Logger.LogWarning($"[UAR] WARNING! {guid}:{website}");
+                Sideloader.Logger.Log(loglevel, $"Outdated zipmod, some items are missing! - {author} : {(string.IsNullOrEmpty(name) ? guid : name)}");
+                Sideloader.Logger.LogWarning($"[UAR] WARNING! Outdated mod detected! {guid} : {website}");
             }
 #endif
             else
             {
                 //did not find a match, we don't have the mod
-                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Missing mod detected! {author}:{(string.IsNullOrEmpty(name) ? guid : name)}");
-                Sideloader.Logger.LogWarning($"[UAR] WARNING! {guid}:{website}");
+                Sideloader.Logger.Log(loglevel, $"Missing zipmod, some items are missing! - {author} : {(string.IsNullOrEmpty(name) ? guid : name)}");
+                Sideloader.Logger.LogWarning($"[UAR] WARNING! Missing mod detected! {guid} : {website}");
             }
         }
 

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
@@ -237,7 +237,7 @@ namespace Sideloader.AutoResolver
                         if (int.TryParse(mainAB, out int x))
                         {
                             //ID found but it conflicts with a vanilla item. Change the ID to avoid conflicts.
-                            ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website);
+                            ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website, extResolve.Name);
                             if (kv.Key.Category.ToString().Contains("ao_") && Sideloader.KeepMissingAccessories.Value && GetNowSceneNames().Any(sceneName => sceneName == "CustomScene"))
                                 kv.Value.SetMethod(structure, 1);
                             else
@@ -252,7 +252,7 @@ namespace Sideloader.AutoResolver
                     else
                     {
                         //ID not found. Change the ID to avoid potential future conflicts.
-                        ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website);
+                        ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website, extResolve.Name);
                         if (kv.Key.Category.ToString().Contains("ao_") && Sideloader.KeepMissingAccessories.Value && GetNowSceneNames().Any(sceneName => sceneName == "CustomScene"))
                             kv.Value.SetMethod(structure, 1);
                         else
@@ -376,7 +376,7 @@ namespace Sideloader.AutoResolver
 
                     var resolveInfo = TryGetResolutionInfo(faceSkinInfo.HeadSlot, ChaListDefine.CategoryNo.fo_head, faceSkinInfo.HeadGUID);
                     if (resolveInfo == null)
-                        ShowGUIDError(faceSkinInfo.HeadGUID, null, null);
+                        ShowGUIDError(faceSkinInfo.HeadGUID, null, null, null);
                     else
                     {
                         if (headID != faceSkinInfo.HeadSlot)
@@ -408,7 +408,7 @@ namespace Sideloader.AutoResolver
 
                     var resolveInfo = TryGetResolutionInfo(faceSkinInfo.HeadSlot, ChaListDefine.CategoryNo.mo_head, faceSkinInfo.HeadGUID);
                     if (resolveInfo == null)
-                        ShowGUIDError(faceSkinInfo.HeadGUID, null, null);
+                        ShowGUIDError(faceSkinInfo.HeadGUID, null, null, null);
                     else
                     {
                         if (headID != faceSkinInfo.HeadSlot)
@@ -479,6 +479,7 @@ namespace Sideloader.AutoResolver
                     {
                         Sideloader.Logger.LogInfo($"ResolveInfo - " +
                                                   $"GUID: {manifest.GUID} " +
+                                                  $"Name: {manifest.Name} " +
                                                   $"Author: {manifest.Author} " +
                                                   $"Website: {manifest.Website} " +
                                                   $"Slot: {int.Parse(kv.Value[0])} " +
@@ -496,7 +497,8 @@ namespace Sideloader.AutoResolver
                         Property = "Ramp",
                         CategoryNo = category,
                         Author = manifest.Author,
-                        Website = manifest.Website
+                        Website = manifest.Website,
+                        Name = manifest.Name
                     });
                 }
                 else
@@ -508,6 +510,7 @@ namespace Sideloader.AutoResolver
                         {
                             Sideloader.Logger.LogInfo($"ResolveInfo - " +
                                                       $"GUID: {manifest.GUID} " +
+                                                      $"Name: {manifest.Name} " +
                                                       $"Author: {manifest.Author}" +
                                                       $"Website: {manifest.Website}" +
                                                       $"Slot: {int.Parse(kv.Value[0])} " +
@@ -525,7 +528,8 @@ namespace Sideloader.AutoResolver
                             Property = propertyKey.ToString(),
                             CategoryNo = category,
                             Author = manifest.Author,
-                            Website = manifest.Website
+                            Website = manifest.Website,
+                            Name = manifest.Name
                         };
                     }));
                 }
@@ -554,21 +558,30 @@ namespace Sideloader.AutoResolver
         }
 #endif
 
-        internal static void ShowGUIDError(string guid, string author, string website)
+        internal static void ShowGUIDError(string guid, string author, string website, string name)
         {
             Logging.LogLevel loglevel = Sideloader.MissingModWarning.Value ? Logging.LogLevel.Warning | Logging.LogLevel.Message : Logging.LogLevel.Warning;
 
             if (LoadedResolutionInfo.Any(x => x.GUID == guid))
+            {
                 //we have the GUID loaded, so the user has an outdated mod
-                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Outdated mod detected! [{guid}]:[By:{author}]:[Site:{website}]");
+                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Outdated mod detected! {author}:{(string.IsNullOrEmpty(name) ? guid : name)}");
+                Sideloader.Logger.LogWarning($"[UAR] WARNING! {guid}:{website}");
+            }
 #if KK || AI || HS2 || KKS
             else if (LoadedStudioResolutionInfo.Any(x => x.GUID == guid))
+            {
                 //we have the GUID loaded, so the user has an outdated mod
-                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Outdated mod detected! [{guid}]:[By:{author}]:[Site:{website}]");
+                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Outdated mod detected! {author}:{(string.IsNullOrEmpty(name) ? guid : name)}");
+                Sideloader.Logger.LogWarning($"[UAR] WARNING! {guid}:{website}");
+            }
 #endif
             else
+            {
                 //did not find a match, we don't have the mod
-                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Missing mod detected! [{guid}]:[By:{author}]:[Site:{website}]");
+                Sideloader.Logger.Log(loglevel, $"[UAR] WARNING! Missing mod detected! {author}:{(string.IsNullOrEmpty(name) ? guid : name)}");
+                Sideloader.Logger.LogWarning($"[UAR] WARNING! {guid}:{website}");
+            }
         }
 
         private static List<string> GetNowSceneNames()

--- a/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.Hooks.cs
+++ b/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.Hooks.cs
@@ -129,7 +129,10 @@ namespace Sideloader.AutoResolver
                                     {
                                         GUID = intResolve.GUID,
                                         Slot = intResolve.Slot,
-                                        LocalSlot = Item.pattern[i].key
+                                        LocalSlot = Item.pattern[i].key,
+                                        Author = intResolve.Author,
+                                        Website = intResolve.Website,
+                                        Name = intResolve.Name
                                     };
 
                                     //Set pattern ID back to original non-resolved ID
@@ -154,7 +157,8 @@ namespace Sideloader.AutoResolver
                                         Slot = intResolve.Slot,
                                         LocalSlot = Item.colors[i].pattern.key,
                                         Author = intResolve.Author,
-                                        Website = intResolve.Website
+                                        Website = intResolve.Website,
+                                        Name = intResolve.Name
                                     };
 
                                     //Set pattern ID back to original non-resolved ID
@@ -181,7 +185,8 @@ namespace Sideloader.AutoResolver
                                     DicKey = Item.dicKey,
                                     ObjectOrder = ItemOrder[Item.dicKey],
                                     Author = extResolve.Author,
-                                    Website = extResolve.Website
+                                    Website = extResolve.Website,
+                                    Name = extResolve.Name
                                 };
                                 ObjectResolutionInfo.Add(intResolve);
 
@@ -205,7 +210,8 @@ namespace Sideloader.AutoResolver
                                 DicKey = Light.dicKey,
                                 ObjectOrder = LightOrder[Light.dicKey],
                                 Author = extResolve.Author,
-                                Website = extResolve.Website
+                                Website = extResolve.Website,
+                                Name = extResolve.Name
                             };
                             ObjectResolutionInfo.Add(intResolve);
 
@@ -231,7 +237,8 @@ namespace Sideloader.AutoResolver
                                 DicKey = CharInfo.dicKey,
                                 ObjectOrder = CharOrder[CharInfo.dicKey],
                                 Author = extResolve.Author,
-                                Website = extResolve.Website
+                                Website = extResolve.Website,
+                                Name = extResolve.Name
                             };
                             ObjectResolutionInfo.Add(intResolve);
 
@@ -261,6 +268,7 @@ namespace Sideloader.AutoResolver
                         ExtendedData.Add("mapInfoGUID", extResolve.GUID);
                         ExtendedData.Add("mapInfoAuthor", extResolve.Author);
                         ExtendedData.Add("mapInfoWebsite", extResolve.Website);
+                        ExtendedData.Add("mapInfoName", extResolve.Name);
 
                         //Set map ID back to default
                         if (Sideloader.DebugLogging.Value)
@@ -280,6 +288,7 @@ namespace Sideloader.AutoResolver
                         ExtendedData.Add("filterInfoGUID", extResolve.GUID);
                         ExtendedData.Add("filterInfoAuthor", extResolve.Author);
                         ExtendedData.Add("filterInfoWebsite", extResolve.Website);
+                        ExtendedData.Add("filterInfoName", extResolve.Name);
 
                         //Set filter ID back to default
                         if (Sideloader.DebugLogging.Value)
@@ -298,6 +307,7 @@ namespace Sideloader.AutoResolver
                         ExtendedData.Add("rampInfoGUID", extResolve.GUID);
                         ExtendedData.Add("rampInfoAuthor", extResolve.Author);
                         ExtendedData.Add("rampInfoWebsite", extResolve.Website);
+                        ExtendedData.Add("rampInfoName", extResolve.Name);
 
                         //Set ramp ID back to default
                         if (Sideloader.DebugLogging.Value)
@@ -318,6 +328,7 @@ namespace Sideloader.AutoResolver
                         ExtendedData.Add("bgmInfoGUID", extResolve.GUID);
                         ExtendedData.Add("bgmInfoAuthor", extResolve.Author);
                         ExtendedData.Add("bgmInfoWebsite", extResolve.Website);
+                        ExtendedData.Add("bgmInfoName", extResolve.Name);
 
                         //Set bgm ID back to default
                         if (Sideloader.DebugLogging.Value)

--- a/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.Hooks.cs
+++ b/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.Hooks.cs
@@ -152,7 +152,9 @@ namespace Sideloader.AutoResolver
                                     {
                                         GUID = intResolve.GUID,
                                         Slot = intResolve.Slot,
-                                        LocalSlot = Item.colors[i].pattern.key
+                                        LocalSlot = Item.colors[i].pattern.key,
+                                        Author = intResolve.Author,
+                                        Website = intResolve.Website
                                     };
 
                                     //Set pattern ID back to original non-resolved ID
@@ -177,7 +179,9 @@ namespace Sideloader.AutoResolver
                                     Slot = extResolve.Slot,
                                     LocalSlot = extResolve.LocalSlot,
                                     DicKey = Item.dicKey,
-                                    ObjectOrder = ItemOrder[Item.dicKey]
+                                    ObjectOrder = ItemOrder[Item.dicKey],
+                                    Author = extResolve.Author,
+                                    Website = extResolve.Website
                                 };
                                 ObjectResolutionInfo.Add(intResolve);
 
@@ -199,7 +203,9 @@ namespace Sideloader.AutoResolver
                                 Slot = extResolve.Slot,
                                 LocalSlot = extResolve.LocalSlot,
                                 DicKey = Light.dicKey,
-                                ObjectOrder = LightOrder[Light.dicKey]
+                                ObjectOrder = LightOrder[Light.dicKey],
+                                Author = extResolve.Author,
+                                Website = extResolve.Website
                             };
                             ObjectResolutionInfo.Add(intResolve);
 
@@ -223,7 +229,9 @@ namespace Sideloader.AutoResolver
                                 Group = extResolve.Group,
                                 Category = extResolve.Category,
                                 DicKey = CharInfo.dicKey,
-                                ObjectOrder = CharOrder[CharInfo.dicKey]
+                                ObjectOrder = CharOrder[CharInfo.dicKey],
+                                Author = extResolve.Author,
+                                Website = extResolve.Website
                             };
                             ObjectResolutionInfo.Add(intResolve);
 
@@ -251,6 +259,8 @@ namespace Sideloader.AutoResolver
                     if (extResolve != null)
                     {
                         ExtendedData.Add("mapInfoGUID", extResolve.GUID);
+                        ExtendedData.Add("mapInfoAuthor", extResolve.Author);
+                        ExtendedData.Add("mapInfoWebsite", extResolve.Website);
 
                         //Set map ID back to default
                         if (Sideloader.DebugLogging.Value)
@@ -268,6 +278,8 @@ namespace Sideloader.AutoResolver
                     if (extResolve != null)
                     {
                         ExtendedData.Add("filterInfoGUID", extResolve.GUID);
+                        ExtendedData.Add("filterInfoAuthor", extResolve.Author);
+                        ExtendedData.Add("filterInfoWebsite", extResolve.Website);
 
                         //Set filter ID back to default
                         if (Sideloader.DebugLogging.Value)
@@ -284,6 +296,8 @@ namespace Sideloader.AutoResolver
                     if (extResolve != null)
                     {
                         ExtendedData.Add("rampInfoGUID", extResolve.GUID);
+                        ExtendedData.Add("rampInfoAuthor", extResolve.Author);
+                        ExtendedData.Add("rampInfoWebsite", extResolve.Website);
 
                         //Set ramp ID back to default
                         if (Sideloader.DebugLogging.Value)
@@ -300,7 +314,10 @@ namespace Sideloader.AutoResolver
                     StudioResolveInfo extResolve = LoadedStudioResolutionInfo.Where(x => x.LocalSlot == bgmID).FirstOrDefault();
                     if (extResolve != null)
                     {
+
                         ExtendedData.Add("bgmInfoGUID", extResolve.GUID);
+                        ExtendedData.Add("bgmInfoAuthor", extResolve.Author);
+                        ExtendedData.Add("bgmInfoWebsite", extResolve.Website);
 
                         //Set bgm ID back to default
                         if (Sideloader.DebugLogging.Value)

--- a/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.StudioPatternResolveInfo.cs
+++ b/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.StudioPatternResolveInfo.cs
@@ -53,6 +53,18 @@ namespace Sideloader.AutoResolver
             /// </summary>
             [Key("LocalSlot")]
             public int LocalSlot;
+
+            /// <summary>
+            /// Author of the mod as defined in the manifest.xml
+            /// </summary>
+            [Key("Author")]
+            public string Author;
+
+            /// <summary>
+            /// Website of the mod as defined in the manifest.xml
+            /// </summary>
+            [Key("Website")]
+            public string Website;
         }
     }
 }

--- a/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.StudioPatternResolveInfo.cs
+++ b/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.StudioPatternResolveInfo.cs
@@ -69,6 +69,7 @@ namespace Sideloader.AutoResolver
             /// <summary>
             /// Name of the mod as defined in the manifest.xml
             /// </summary>
+            [Key("Name")]
             public string Name;
         }
     }

--- a/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.StudioPatternResolveInfo.cs
+++ b/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.StudioPatternResolveInfo.cs
@@ -65,6 +65,11 @@ namespace Sideloader.AutoResolver
             /// </summary>
             [Key("Website")]
             public string Website;
+
+            /// <summary>
+            /// Name of the mod as defined in the manifest.xml
+            /// </summary>
+            public string Name;
         }
     }
 }

--- a/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.StudioResolveInfo.cs
+++ b/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.StudioResolveInfo.cs
@@ -51,6 +51,18 @@ namespace Sideloader.AutoResolver
         [Key("Category")]
         public int Category { get; set; }
 
+        /// <summary>
+        /// Author of the mod as defined in the manifest.
+        /// </summary>
+        [Key("Author")]
+        public string Author { get; set; }
+
+        /// <summary>
+        /// /// Author of the mod as defined in the manifest.
+        /// </summary>
+        [Key("Website")]
+        public string Website { get; set; }
+
         internal static StudioResolveInfo Deserialize(byte[] data) => MessagePackSerializer.Deserialize<StudioResolveInfo>(data);
 
         internal byte[] Serialize() => MessagePackSerializer.Serialize(this);

--- a/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.StudioResolveInfo.cs
+++ b/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.StudioResolveInfo.cs
@@ -63,6 +63,12 @@ namespace Sideloader.AutoResolver
         [Key("Website")]
         public string Website { get; set; }
 
+        /// <summary>
+        /// Display name of the mod as defined in the manifest.xml
+        /// </summary>
+        [Key("Name")]
+        public string Name { get; set; }
+
         internal static StudioResolveInfo Deserialize(byte[] data) => MessagePackSerializer.Deserialize<StudioResolveInfo>(data);
 
         internal byte[] Serialize() => MessagePackSerializer.Serialize(this);

--- a/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.cs
+++ b/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.cs
@@ -43,7 +43,9 @@ namespace Sideloader.AutoResolver
                         GUID = manifest.GUID,
                         Slot = slot,
                         LocalSlot = newSlot,
-                        ResolveItem = false
+                        ResolveItem = false,
+                        Author = manifest.Author,
+                        Website = manifest.Website
                     });
 
                     entry[0] = newSlot.ToString();
@@ -61,7 +63,9 @@ namespace Sideloader.AutoResolver
                         GUID = manifest.GUID,
                         Slot = int.Parse(entry[0]),
                         LocalSlot = int.Parse(entry[0]),
-                        ResolveItem = false
+                        ResolveItem = false,
+                        Author = manifest.Author,
+                        Website = manifest.Website
                     });
                 }
             }
@@ -76,7 +80,9 @@ namespace Sideloader.AutoResolver
                         GUID = manifest.GUID,
                         Slot = int.Parse(entry[0]),
                         LocalSlot = newSlot,
-                        ResolveItem = true
+                        ResolveItem = true,
+                        Author = manifest.Author,
+                        Website = manifest.Website
                     };
 
                     //Group and category is important for animations since the same ID can be used in different groups and categories
@@ -98,6 +104,8 @@ namespace Sideloader.AutoResolver
                     {
                         Sideloader.Logger.LogInfo($"StudioResolveInfo - " +
                                                   $"GUID: {manifest.GUID} " +
+                                                  $"Author: {manifest.Author} " +
+                                                  $"Website: {manifest.Website} " +
                                                   $"Slot: {int.Parse(entry[0])} " +
                                                   $"LocalSlot: {newSlot} " +
                                                   $"Count: {LoadedStudioResolutionInfo.Count}");
@@ -162,7 +170,7 @@ namespace Sideloader.AutoResolver
                     Item.no = intResolve.LocalSlot;
                 }
                 else if (resolveType == ResolveType.Load)
-                    ShowGUIDError(extResolve.GUID);
+                    ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website);
             }
             else if (OI is OILightInfo Light)
             {
@@ -174,7 +182,7 @@ namespace Sideloader.AutoResolver
                     Light.no = intResolve.LocalSlot;
                 }
                 else if (resolveType == ResolveType.Load)
-                    ShowGUIDError(extResolve.GUID);
+                    ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website);
             }
             else if (OI is OICharInfo CharInfo)
             {
@@ -187,7 +195,7 @@ namespace Sideloader.AutoResolver
                     CharInfo.animeInfo.no = intResolve.LocalSlot;
                 }
                 else if (resolveType == ResolveType.Load)
-                    ShowGUIDError(extResolve.GUID);
+                    ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website);
             }
         }
 
@@ -281,7 +289,7 @@ namespace Sideloader.AutoResolver
                     }
                     else if (resolveType == ResolveType.Load)
                     {
-                        ShowGUIDError(patternInfo.GUID);
+                        ShowGUIDError(patternInfo.GUID, patternInfo.Author, patternInfo.Website);
                         Item.pattern[i].key = BaseSlotID - 1;
                     }
                 }
@@ -299,7 +307,7 @@ namespace Sideloader.AutoResolver
                     }
                     else if (resolveType == ResolveType.Load)
                     {
-                        ShowGUIDError(patternInfo.GUID);
+                        ShowGUIDError(patternInfo.GUID, patternInfo.Author, patternInfo.Website);
                         Item.colors[i].pattern.key = BaseSlotID - 1;
                     }
                 }
@@ -318,6 +326,8 @@ namespace Sideloader.AutoResolver
             if (extData != null && extData.data.ContainsKey("mapInfoGUID"))
             {
                 string MapGUID = (string)extData.data["mapInfoGUID"];
+                string MapAuthor = (string)extData.data["mapInfoAuthor"];
+                string MapWebsite = (string)extData.data["mapInfoWebsite"];
 
                 StudioResolveInfo intResolve = LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.Slot == MapID && x.GUID == MapGUID);
                 if (intResolve != null)
@@ -327,7 +337,7 @@ namespace Sideloader.AutoResolver
                     SetMapID(intResolve.LocalSlot);
                 }
                 else
-                    ShowGUIDError(MapGUID);
+                    ShowGUIDError(MapGUID, MapAuthor, MapWebsite);
             }
             else if (resolveType == ResolveType.Load)
             {
@@ -359,6 +369,9 @@ namespace Sideloader.AutoResolver
             if (extData != null && extData.data.ContainsKey("filterInfoGUID"))
             {
                 string filterGUID = (string)extData.data["filterInfoGUID"];
+                string filterAuthor = (string)extData.data["filterInfoAuthor"];
+                string filterWebsite = (string)extData.data["filterInfoWebsite"];
+
 
                 StudioResolveInfo intResolve = LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.Slot == filterID && x.GUID == filterGUID);
                 if (intResolve != null)
@@ -368,7 +381,7 @@ namespace Sideloader.AutoResolver
                     Studio.Studio.Instance.sceneInfo.aceNo = intResolve.LocalSlot;
                 }
                 else
-                    ShowGUIDError(filterGUID);
+                    ShowGUIDError(filterGUID, filterAuthor, filterWebsite);
             }
             else if (resolveType == ResolveType.Load)
             {
@@ -401,6 +414,8 @@ namespace Sideloader.AutoResolver
             if (extData != null && extData.data.ContainsKey("rampInfoGUID"))
             {
                 string rampGUID = (string)extData.data["rampInfoGUID"];
+                string rampAuthor = (string)extData.data["rampInfoAuthor"];
+                string rampWebsite = (string)extData.data["rampInfoWebsite"];
 
                 ResolveInfo intResolve = LoadedResolutionInfo.FirstOrDefault(x => x.Property == "Ramp" && x.GUID == rampGUID && x.Slot == rampID);
                 if (intResolve != null)
@@ -411,7 +426,7 @@ namespace Sideloader.AutoResolver
                     Studio.Studio.Instance.sceneInfo.rampG = intResolve.LocalSlot;
                 }
                 else
-                    ShowGUIDError(rampGUID);
+                    ShowGUIDError(rampGUID, rampAuthor, rampWebsite);
             }
             else if (resolveType == ResolveType.Load)
             {
@@ -446,6 +461,8 @@ namespace Sideloader.AutoResolver
             if (extData != null && extData.data.ContainsKey("bgmInfoGUID"))
             {
                 string bgmGUID = (string)extData.data["bgmInfoGUID"];
+                string bgmAuthor = (string)extData.data["bgmInfoAuthor"];
+                string bgmWebsite = (string)extData.data["bgmInfoWebsite"];
 
                 StudioResolveInfo intResolve = LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.Slot == bgmID && x.GUID == bgmGUID);
                 if (intResolve != null)
@@ -455,7 +472,7 @@ namespace Sideloader.AutoResolver
                     Singleton<Studio.Studio>.Instance.sceneInfo.bgmCtrl.no = intResolve.LocalSlot;
                 }
                 else
-                    ShowGUIDError(bgmGUID);
+                    ShowGUIDError(bgmGUID, bgmAuthor, bgmWebsite);
             }
             else if (resolveType == ResolveType.Load)
             {

--- a/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.cs
+++ b/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.cs
@@ -326,8 +326,13 @@ namespace Sideloader.AutoResolver
             if (extData != null && extData.data.ContainsKey("mapInfoGUID"))
             {
                 string MapGUID = (string)extData.data["mapInfoGUID"];
-                string MapAuthor = (string)extData.data["mapInfoAuthor"];
-                string MapWebsite = (string)extData.data["mapInfoWebsite"];
+
+                string MapAuthor = null;
+                if (extData.data.TryGetValue("mapInfoAuthor", out object MapAuthorData))
+                    MapAuthor = (string)MapAuthorData;
+                string MapWebsite = null;
+                if (extData.data.TryGetValue("mapInfoWebsite", out object MapWebsiteData))
+                    MapWebsite = (string)MapWebsiteData;
 
                 StudioResolveInfo intResolve = LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.Slot == MapID && x.GUID == MapGUID);
                 if (intResolve != null)
@@ -369,8 +374,13 @@ namespace Sideloader.AutoResolver
             if (extData != null && extData.data.ContainsKey("filterInfoGUID"))
             {
                 string filterGUID = (string)extData.data["filterInfoGUID"];
-                string filterAuthor = (string)extData.data["filterInfoAuthor"];
-                string filterWebsite = (string)extData.data["filterInfoWebsite"];
+
+                string filterAuthor = null;
+                if (extData.data.TryGetValue("filterInfoAuthor", out object filterAuthorData))
+                    filterAuthor = (string)filterAuthorData;
+                string filterWebsite = null;
+                if (extData.data.TryGetValue("filterInfoWebsite", out object filterWebsiteData))
+                    filterWebsite = (string)filterWebsiteData;
 
 
                 StudioResolveInfo intResolve = LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.Slot == filterID && x.GUID == filterGUID);
@@ -414,8 +424,13 @@ namespace Sideloader.AutoResolver
             if (extData != null && extData.data.ContainsKey("rampInfoGUID"))
             {
                 string rampGUID = (string)extData.data["rampInfoGUID"];
-                string rampAuthor = (string)extData.data["rampInfoAuthor"];
-                string rampWebsite = (string)extData.data["rampInfoWebsite"];
+
+                string rampAuthor = null;
+                if (extData.data.TryGetValue("rampInfoAuthor", out object rampAuthorData))
+                    rampAuthor = (string)rampAuthorData;
+                string rampWebsite = null;
+                if (extData.data.TryGetValue("rampInfoWebsite", out object rampWebsiteData))
+                    rampWebsite = (string)rampWebsiteData;
 
                 ResolveInfo intResolve = LoadedResolutionInfo.FirstOrDefault(x => x.Property == "Ramp" && x.GUID == rampGUID && x.Slot == rampID);
                 if (intResolve != null)
@@ -461,8 +476,13 @@ namespace Sideloader.AutoResolver
             if (extData != null && extData.data.ContainsKey("bgmInfoGUID"))
             {
                 string bgmGUID = (string)extData.data["bgmInfoGUID"];
-                string bgmAuthor = (string)extData.data["bgmInfoAuthor"];
-                string bgmWebsite = (string)extData.data["bgmInfoWebsite"];
+
+                string bgmAuthor = null;
+                if (extData.data.TryGetValue("bgmInfoAuthor", out object bgmAuthorData))
+                    bgmAuthor = (string)bgmAuthorData;
+                string bgmWebsite = null;
+                if (extData.data.TryGetValue("bgmInfoWebsite", out object bgmWebsiteData))
+                    bgmWebsite = (string)bgmWebsiteData;
 
                 StudioResolveInfo intResolve = LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.Slot == bgmID && x.GUID == bgmGUID);
                 if (intResolve != null)

--- a/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.cs
+++ b/src/Core_Sideloader_Studio/UniversalAutoResolver/Core.UAR.Studio.cs
@@ -45,7 +45,8 @@ namespace Sideloader.AutoResolver
                         LocalSlot = newSlot,
                         ResolveItem = false,
                         Author = manifest.Author,
-                        Website = manifest.Website
+                        Website = manifest.Website,
+                        Name = manifest.Name
                     });
 
                     entry[0] = newSlot.ToString();
@@ -65,7 +66,8 @@ namespace Sideloader.AutoResolver
                         LocalSlot = int.Parse(entry[0]),
                         ResolveItem = false,
                         Author = manifest.Author,
-                        Website = manifest.Website
+                        Website = manifest.Website,
+                        Name = manifest.Name
                     });
                 }
             }
@@ -82,7 +84,8 @@ namespace Sideloader.AutoResolver
                         LocalSlot = newSlot,
                         ResolveItem = true,
                         Author = manifest.Author,
-                        Website = manifest.Website
+                        Website = manifest.Website,
+                        Name = manifest.Name
                     };
 
                     //Group and category is important for animations since the same ID can be used in different groups and categories
@@ -104,6 +107,7 @@ namespace Sideloader.AutoResolver
                     {
                         Sideloader.Logger.LogInfo($"StudioResolveInfo - " +
                                                   $"GUID: {manifest.GUID} " +
+                                                  $"Name: {manifest.Name} " +
                                                   $"Author: {manifest.Author} " +
                                                   $"Website: {manifest.Website} " +
                                                   $"Slot: {int.Parse(entry[0])} " +
@@ -170,7 +174,7 @@ namespace Sideloader.AutoResolver
                     Item.no = intResolve.LocalSlot;
                 }
                 else if (resolveType == ResolveType.Load)
-                    ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website);
+                    ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website, extResolve.Name);
             }
             else if (OI is OILightInfo Light)
             {
@@ -182,7 +186,7 @@ namespace Sideloader.AutoResolver
                     Light.no = intResolve.LocalSlot;
                 }
                 else if (resolveType == ResolveType.Load)
-                    ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website);
+                    ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website, extResolve.Name);
             }
             else if (OI is OICharInfo CharInfo)
             {
@@ -195,7 +199,7 @@ namespace Sideloader.AutoResolver
                     CharInfo.animeInfo.no = intResolve.LocalSlot;
                 }
                 else if (resolveType == ResolveType.Load)
-                    ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website);
+                    ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website, extResolve.Name);
             }
         }
 
@@ -289,7 +293,7 @@ namespace Sideloader.AutoResolver
                     }
                     else if (resolveType == ResolveType.Load)
                     {
-                        ShowGUIDError(patternInfo.GUID, patternInfo.Author, patternInfo.Website);
+                        ShowGUIDError(patternInfo.GUID, patternInfo.Author, patternInfo.Website, patternInfo.Name);
                         Item.pattern[i].key = BaseSlotID - 1;
                     }
                 }
@@ -307,7 +311,7 @@ namespace Sideloader.AutoResolver
                     }
                     else if (resolveType == ResolveType.Load)
                     {
-                        ShowGUIDError(patternInfo.GUID, patternInfo.Author, patternInfo.Website);
+                        ShowGUIDError(patternInfo.GUID, patternInfo.Author, patternInfo.Website, patternInfo.Name);
                         Item.colors[i].pattern.key = BaseSlotID - 1;
                     }
                 }
@@ -333,6 +337,9 @@ namespace Sideloader.AutoResolver
                 string MapWebsite = null;
                 if (extData.data.TryGetValue("mapInfoWebsite", out object MapWebsiteData))
                     MapWebsite = (string)MapWebsiteData;
+                string MapName = null;
+                if (extData.data.TryGetValue("mapInfoName", out object MapNameData))
+                    MapName = (string)MapNameData;
 
                 StudioResolveInfo intResolve = LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.Slot == MapID && x.GUID == MapGUID);
                 if (intResolve != null)
@@ -342,7 +349,7 @@ namespace Sideloader.AutoResolver
                     SetMapID(intResolve.LocalSlot);
                 }
                 else
-                    ShowGUIDError(MapGUID, MapAuthor, MapWebsite);
+                    ShowGUIDError(MapGUID, MapAuthor, MapWebsite, MapName);
             }
             else if (resolveType == ResolveType.Load)
             {
@@ -381,6 +388,9 @@ namespace Sideloader.AutoResolver
                 string filterWebsite = null;
                 if (extData.data.TryGetValue("filterInfoWebsite", out object filterWebsiteData))
                     filterWebsite = (string)filterWebsiteData;
+                string filterName = null;
+                if (extData.data.TryGetValue("filterInfoName", out object filterNameData))
+                    filterName = (string)filterNameData;
 
 
                 StudioResolveInfo intResolve = LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.Slot == filterID && x.GUID == filterGUID);
@@ -391,7 +401,7 @@ namespace Sideloader.AutoResolver
                     Studio.Studio.Instance.sceneInfo.aceNo = intResolve.LocalSlot;
                 }
                 else
-                    ShowGUIDError(filterGUID, filterAuthor, filterWebsite);
+                    ShowGUIDError(filterGUID, filterAuthor, filterWebsite, filterName);
             }
             else if (resolveType == ResolveType.Load)
             {
@@ -431,6 +441,9 @@ namespace Sideloader.AutoResolver
                 string rampWebsite = null;
                 if (extData.data.TryGetValue("rampInfoWebsite", out object rampWebsiteData))
                     rampWebsite = (string)rampWebsiteData;
+                string rampName = null;
+                if (extData.data.TryGetValue("rampInfoName", out object rampNameData))
+                    rampName = (string)rampNameData;
 
                 ResolveInfo intResolve = LoadedResolutionInfo.FirstOrDefault(x => x.Property == "Ramp" && x.GUID == rampGUID && x.Slot == rampID);
                 if (intResolve != null)
@@ -441,7 +454,7 @@ namespace Sideloader.AutoResolver
                     Studio.Studio.Instance.sceneInfo.rampG = intResolve.LocalSlot;
                 }
                 else
-                    ShowGUIDError(rampGUID, rampAuthor, rampWebsite);
+                    ShowGUIDError(rampGUID, rampAuthor, rampWebsite, rampName);
             }
             else if (resolveType == ResolveType.Load)
             {
@@ -483,6 +496,9 @@ namespace Sideloader.AutoResolver
                 string bgmWebsite = null;
                 if (extData.data.TryGetValue("bgmInfoWebsite", out object bgmWebsiteData))
                     bgmWebsite = (string)bgmWebsiteData;
+                string bgmName = null;
+                if (extData.data.TryGetValue("bgmInfoName", out object bgmNameData))
+                    bgmName = (string)bgmNameData;
 
                 StudioResolveInfo intResolve = LoadedStudioResolutionInfo.FirstOrDefault(x => x.ResolveItem && x.Slot == bgmID && x.GUID == bgmGUID);
                 if (intResolve != null)
@@ -492,7 +508,7 @@ namespace Sideloader.AutoResolver
                     Singleton<Studio.Studio>.Instance.sceneInfo.bgmCtrl.no = intResolve.LocalSlot;
                 }
                 else
-                    ShowGUIDError(bgmGUID, bgmAuthor, bgmWebsite);
+                    ShowGUIDError(bgmGUID, bgmAuthor, bgmWebsite, bgmName);
             }
             else if (resolveType == ResolveType.Load)
             {


### PR DESCRIPTION
One of the most common help questions with Sideloader based setups is 'Where is this mod?'. Currently only the GUID is exposed to the user who has the card, which is frequently unhelpful in tracking down the source of the mod. 

This PR stores the Author and Website fields of the manifest file alongside the GUID and uses that to fuel better missing/outdated mod warnings.

Obviously this'll rely on mod authors filling in the manifest information and will only read for cards going forward...but hopefully it'll help users to track down mods.