### PR TITLE
[EC] Retain messagepack ext data

### DIFF
--- a/src/Core_ExtensibleSaveFormat/Core.ExtendedSave.Extensions.cs
+++ b/src/Core_ExtensibleSaveFormat/Core.ExtendedSave.Extensions.cs
@@ -58,7 +58,27 @@ namespace ExtensibleSaveFormat
                 Logger.LogError(ex);
             }
         }
+        internal static void TransferSerializedExtendedData(this object destination, object source)
+        {
+            try
+            {
+                if (source == null) throw new System.ArgumentNullException(nameof(source));
 
+                var tv = Traverse.Create(source);
+                var prop = tv.Property(ExtendedSaveDataPropertyName);
+
+                if (!prop.PropertyExists())
+                    throw new System.NotSupportedException($"The type '{source?.GetType()}' does not have the '{ExtendedSaveDataPropertyName}' property. Make sure the extended save patcher is installed and working.");
+
+                var data = prop.GetValue();
+                if (data == null) return;
+                Traverse.Create(destination).Property(ExtendedSaveDataPropertyName).SetValue(data);
+            }
+            catch (System.Exception ex)
+            {
+                Logger.LogError(ex);
+            }
+        }
 #if KK || KKS || EC
         //Body
         public static Dictionary<string, PluginData> GetAllExtendedData(this ChaFileBody messagePackObject) => GetExtendedData(messagePackObject);

--- a/src/Core_ExtensibleSaveFormat_Patcher/Patcher.cs
+++ b/src/Core_ExtensibleSaveFormat_Patcher/Patcher.cs
@@ -61,8 +61,10 @@ namespace ExtensibleSaveFormat
 
             messagePackObject = ass.MainModule.GetType("ChaFileParameter/Awnser");
             PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+
             messagePackObject = ass.MainModule.GetType("ChaFileParameter/Denial");
             PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+
             messagePackObject = ass.MainModule.GetType("ChaFileParameter/Attribute");
             PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
 #endif
@@ -76,8 +78,48 @@ namespace ExtensibleSaveFormat
 #endif
 
 #if EC
+
             messagePackObject = ass.MainModule.GetType("ChaFileFace/ChaFileMakeup");
             PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+
+            //import messagepacks are different from normal messagepacks in-game
+            #region Import MessagePacks
+            //Body
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileBody");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+
+            //Face
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileFace");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileFace/PupilInfo");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+
+            //Hair
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileHair");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileHair/PartsInfo");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+
+            //Clothes
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileClothes");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileClothes/PartsInfo");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileClothes/PartsInfo/ColorInfo");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+
+            //Accessory
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileAccessory");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileAccessory/PartsInfo");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileStatus");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+
+            messagePackObject = ass.MainModule.GetType("KoikatsuCharaFile.ChaFileParameter");
+            PropertyInject(ass, messagePackObject, ExtendedSave.ExtendedSaveDataPropertyName, typeof(object));
+            #endregion
 #endif
 
 #if AI || HS2


### PR DESCRIPTION
Issue: EC doesn't use the same messagepack object in the main-game and on import and data is copied by property/field to EC format. Data directly saved on the messagepacks will not be imported and be discarded.

Also stupid me forgot to check that getallextendeddata doesn't overload onto itself