### PR TITLE
[Sideloader] Allow arbitrary categories of accessories instead of only ao_*

### DIFF
--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.Hooks.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.Hooks.cs
@@ -123,7 +123,7 @@ namespace Sideloader.AutoResolver
                                 continue;
 
                         //For accessories, make sure we're checking the appropriate category
-                        if (kv.Key.Category.ToString().Contains("ao_"))
+                        if (obj is ChaFileAccessory.PartsInfo)
                         {
                             ChaFileAccessory.PartsInfo AccessoryInfo = (ChaFileAccessory.PartsInfo)obj;
 
@@ -132,6 +132,11 @@ namespace Sideloader.AutoResolver
                                 //If the current category does not match the accessory's category do not attempt a resolution info lookup
                                 continue;
                             }
+                        }
+                        else if (kv.Key.Prefix == StructReference.AccessoryPropPrefix)
+                        {
+                            // If we are not an accessory then skip trying to resolve accessory props
+                            continue;
                         }
 
                         var info = TryGetResolutionInfo(kv.Key.ToString(), slot);
@@ -284,10 +289,10 @@ namespace Sideloader.AutoResolver
 #elif AI || HS2
                             if (Lists.InternalDataList[(int)kv.Key.Category].ContainsKey(slot))
 #endif
-                            continue;
+                                continue;
 
                         //For accessories, make sure we're checking the appropriate category
-                        if (kv.Key.Category.ToString().Contains("ao_"))
+                        if (obj is ChaFileAccessory.PartsInfo)
                         {
                             ChaFileAccessory.PartsInfo AccessoryInfo = (ChaFileAccessory.PartsInfo)obj;
 
@@ -296,6 +301,11 @@ namespace Sideloader.AutoResolver
                                 //If the current category does not match the accessory's category do not attempt a resolution info lookup
                                 continue;
                             }
+                        }
+                        else if (kv.Key.Prefix == StructReference.AccessoryPropPrefix)
+                        {
+                            // If we are not an accessory then skip trying to resolve accessory props
+                            continue;
                         }
 
                         var info = TryGetResolutionInfo(kv.Key.ToString(), slot);

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.StructReference.AI.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.StructReference.AI.cs
@@ -435,29 +435,14 @@ namespace Sideloader.AutoResolver
         #endregion
 
         #region ChaFileAccessory.PartsInfo
+
+        internal static readonly string AccessoryPropPrefix = $"{nameof(ChaFileAccessory)}.{nameof(ChaFileAccessory.PartsInfo)}";
+
         private static Dictionary<CategoryProperty, StructValue<int>> ChaFileAccessoryPartsInfoGenerator()
         {
-            string prefix = $"{nameof(ChaFileAccessory)}.{nameof(ChaFileAccessory.PartsInfo)}";
+            var baseProperties = Enum.GetValues(typeof(CategoryNo)).Cast<CategoryNo>().Select(x => new CategoryProperty(x, "id", AccessoryPropPrefix)).ToList();
 
-            var baseProperties = new List<CategoryProperty>
-            {
-                new CategoryProperty(CategoryNo.ao_none , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_head, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_ear, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_glasses, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_face, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_neck, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_shoulder, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_chest, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_waist, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_back, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_arm, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_hand, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_leg, "id", prefix),
-                new CategoryProperty(CategoryNo.ao_kokan, "id", prefix)
-            };
-
-            var generatedProperties = GeneratePropertyInfoDictionary(typeof(ChaFileAccessory.PartsInfo), baseProperties, prefix);
+            var generatedProperties = GeneratePropertyInfoDictionary(typeof(ChaFileAccessory.PartsInfo), baseProperties, AccessoryPropPrefix);
 
             return generatedProperties;
         }

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.StructReference.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.StructReference.cs
@@ -611,20 +611,7 @@ namespace Sideloader.AutoResolver
         {
             string prefix = $"{nameof(ChaFileAccessory)}.{nameof(ChaFileAccessory.PartsInfo)}";
 
-            var baseProperties = new List<CategoryProperty>
-            {
-                new CategoryProperty(CategoryNo.ao_none , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_hair , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_head , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_face , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_neck , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_body , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_waist , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_leg , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_arm , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_hand , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_kokan , "id", prefix)
-            };
+            var baseProperties = Enum.GetValues(typeof(CategoryNo)).Cast<CategoryNo>().Select(x => new CategoryProperty(x, "id", prefix)).ToList();
 
             var generatedProperties = GeneratePropertyInfoDictionary(typeof(ChaFileAccessory.PartsInfo), baseProperties, prefix);
 

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.StructReference.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.StructReference.cs
@@ -607,13 +607,12 @@ namespace Sideloader.AutoResolver
         #endregion
 
         #region ChaFileAccessory.PartsInfo
+        internal static readonly string AccessoryPropPrefix = $"{nameof(ChaFileAccessory)}.{nameof(ChaFileAccessory.PartsInfo)}";
         private static Dictionary<CategoryProperty, StructValue<int>> ChaFileAccessoryPartsInfoGenerator()
         {
-            string prefix = $"{nameof(ChaFileAccessory)}.{nameof(ChaFileAccessory.PartsInfo)}";
+            var baseProperties = Enum.GetValues(typeof(CategoryNo)).Cast<CategoryNo>().Select(x => new CategoryProperty(x, "id", AccessoryPropPrefix)).ToList();
 
-            var baseProperties = Enum.GetValues(typeof(CategoryNo)).Cast<CategoryNo>().Select(x => new CategoryProperty(x, "id", prefix)).ToList();
-
-            var generatedProperties = GeneratePropertyInfoDictionary(typeof(ChaFileAccessory.PartsInfo), baseProperties, prefix);
+            var generatedProperties = GeneratePropertyInfoDictionary(typeof(ChaFileAccessory.PartsInfo), baseProperties, AccessoryPropPrefix);
 
             return generatedProperties;
         }

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.StructReference.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.StructReference.cs
@@ -608,6 +608,7 @@ namespace Sideloader.AutoResolver
 
         #region ChaFileAccessory.PartsInfo
         internal static readonly string AccessoryPropPrefix = $"{nameof(ChaFileAccessory)}.{nameof(ChaFileAccessory.PartsInfo)}";
+
         private static Dictionary<CategoryProperty, StructValue<int>> ChaFileAccessoryPartsInfoGenerator()
         {
             var baseProperties = Enum.GetValues(typeof(CategoryNo)).Cast<CategoryNo>().Select(x => new CategoryProperty(x, "id", AccessoryPropPrefix)).ToList();

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
@@ -181,15 +181,20 @@ namespace Sideloader.AutoResolver
                 string property = $"{propertyPrefix}{kv.Key}";
 
                 //For accessories, make sure we're checking the appropriate category
-                if (kv.Key.Category.ToString().Contains("ao_"))
+                if (structure is ChaFileAccessory.PartsInfo)
                 {
+                    // Do not combine this cast with the is check above to keep compatibility with Jetpack's transplier hook
                     ChaFileAccessory.PartsInfo AccessoryInfo = (ChaFileAccessory.PartsInfo)structure;
-
                     if ((int)kv.Key.Category != AccessoryInfo.type)
                     {
-                        //If the current category does not match the category saved to the card do not attempt resolving
+                        //If the current accessory category does not match the category saved to the card do not attempt resolving
                         continue;
                     }
+                }
+                else if (kv.Key.Prefix == StructReference.AccessoryPropPrefix)
+                {
+                    // If we are not an accessory then skip trying to resolve accessory props
+                    continue;
                 }
 
                 ResolveInfo extResolve = extInfo?.FirstOrDefault(x => x.Property == property);

--- a/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
+++ b/src/Core_Sideloader/UniversalAutoResolver/Core.UAR.cs
@@ -243,7 +243,7 @@ namespace Sideloader.AutoResolver
                         {
                             //ID found but it conflicts with a vanilla item. Change the ID to avoid conflicts.
                             ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website, extResolve.Name);
-                            if (kv.Key.Category.ToString().Contains("ao_") && Sideloader.KeepMissingAccessories.Value && GetNowSceneNames().Any(sceneName => sceneName == "CustomScene"))
+                            if (structure is ChaFileAccessory.PartsInfo && Sideloader.KeepMissingAccessories.Value && GetNowSceneNames().Any(sceneName => sceneName == "CustomScene"))
                                 kv.Value.SetMethod(structure, 1);
                             else
                                 kv.Value.SetMethod(structure, BaseSlotID - 1);
@@ -258,7 +258,7 @@ namespace Sideloader.AutoResolver
                     {
                         //ID not found. Change the ID to avoid potential future conflicts.
                         ShowGUIDError(extResolve.GUID, extResolve.Author, extResolve.Website, extResolve.Name);
-                        if (kv.Key.Category.ToString().Contains("ao_") && Sideloader.KeepMissingAccessories.Value && GetNowSceneNames().Any(sceneName => sceneName == "CustomScene"))
+                        if (structure is ChaFileAccessory.PartsInfo && Sideloader.KeepMissingAccessories.Value && GetNowSceneNames().Any(sceneName => sceneName == "CustomScene"))
                             kv.Value.SetMethod(structure, 1);
                         else
                             kv.Value.SetMethod(structure, BaseSlotID - 1);
@@ -307,7 +307,7 @@ namespace Sideloader.AutoResolver
                 //No match was found
                 if (Sideloader.DebugLogging.Value)
                     Sideloader.Logger.LogDebug($"Compatibility resolving failed, no match found for ID {kv.Value.GetMethod(structure)} Category {kv.Key.Category}");
-                if (kv.Key.Category.ToString().Contains("ao_") && Sideloader.KeepMissingAccessories.Value && GetNowSceneNames().Any(sceneName => sceneName == "CustomScene"))
+                if (structure is ChaFileAccessory.PartsInfo && Sideloader.KeepMissingAccessories.Value && GetNowSceneNames().Any(sceneName => sceneName == "CustomScene"))
                     kv.Value.SetMethod(structure, 1);
             }
         }


### PR DESCRIPTION
Other categories can be used if a plugin like ClothesToAccessories removes the ao_* only restriction.