### PR TITLE
[ColorCorrector] Don't override bloom stength by default (Fixes #179)

### DIFF
--- a/src/Core_ColorCorrector/Core.ColorCorrector.cs
+++ b/src/Core_ColorCorrector/Core.ColorCorrector.cs
@@ -35,7 +35,7 @@ namespace ColorCorrector
         {
             SaturationEnabled = Config.Bind("Post Processing Settings", "Enable saturation filter", true, new ConfigDescription("Whether default saturation filter will be applied to the game. This setting has no effect in Studio."));
             OverrideBloomStrength = Config.Bind("Post Processing Settings", "Enable bloom strength override", false, new ConfigDescription("Override the strength of the bloom filter. Not active in Studio, control bloom settings through the in game Scene Effects menu."));
-            BloomStrength = Config.Bind("Post Processing Settings", "Bloom strength", DefaultBloomStrength, new ConfigDescription("Strength of the bloom filter.", new AcceptableValueRange<float>(0f, MaxBloomStrength)));
+            BloomStrength = Config.Bind("Post Processing Settings", "Bloom strength", DefaultBloomStrength, new ConfigDescription("Strength of the bloom filter override. Bloom strength override has to be enabled for this setting to have an effect.", new AcceptableValueRange<float>(0f, MaxBloomStrength)));
             SaturationEnabled.SettingChanged += OnSettingChanged;
             OverrideBloomStrength.SettingChanged += OnSettingChanged;
             BloomStrength.SettingChanged += OnSettingChanged;

--- a/src/Core_ColorCorrector/Core.ColorCorrector.cs
+++ b/src/Core_ColorCorrector/Core.ColorCorrector.cs
@@ -18,6 +18,7 @@ namespace ColorCorrector
         public const string Version = Metadata.PluginsVersion;
 
         private ConfigEntry<bool> SaturationEnabled { get; set; }
+        private ConfigEntry<bool> OverrideBloomStrength { get; set; }
         private ConfigEntry<float> BloomStrength { get; set; }
 
         private AmplifyColorEffect _amplifyComponent;
@@ -33,8 +34,10 @@ namespace ColorCorrector
         private void Start()
         {
             SaturationEnabled = Config.Bind("Post Processing Settings", "Enable saturation filter", true, new ConfigDescription("Whether default saturation filter will be applied to the game. This setting has no effect in Studio."));
-            BloomStrength = Config.Bind("Post Processing Settings", "Bloom strength", DefaultBloomStrength, new ConfigDescription("Strength of the bloom filter. Not active in Studio, control bloom settings through the in game Scene Effects menu.", new AcceptableValueRange<float>(0f, MaxBloomStrength)));
+            OverrideBloomStrength = Config.Bind("Post Processing Settings", "Enable bloom strength override", false, new ConfigDescription("Override the strength of the bloom filter. Not active in Studio, control bloom settings through the in game Scene Effects menu."));
+            BloomStrength = Config.Bind("Post Processing Settings", "Bloom strength", DefaultBloomStrength, new ConfigDescription("Strength of the bloom filter.", new AcceptableValueRange<float>(0f, MaxBloomStrength)));
             SaturationEnabled.SettingChanged += OnSettingChanged;
+            OverrideBloomStrength.SettingChanged += OnSettingChanged;
             BloomStrength.SettingChanged += OnSettingChanged;
 
             SceneManager.sceneLoaded += LevelFinishedLoading;
@@ -48,23 +51,23 @@ namespace ColorCorrector
                 _bloomComponent = Camera.main.gameObject.GetComponent<BloomAndFlares>();
 
 #if KK || EC
-                SetEffects(SaturationEnabled.Value, BloomStrength.Value);
+                SetEffects();
 #elif KKS
                 StartCoroutine(DelayMethod(() =>
                 {
-                    SetEffects(SaturationEnabled.Value, BloomStrength.Value);
+                    SetEffects();
                 }));
 #endif
             }
         }
 
-        private void SetEffects(bool satEnabled, float bloomPower)
+        private void SetEffects()
         {
             if (_amplifyComponent != null)
-                _amplifyComponent.enabled = satEnabled;
+                _amplifyComponent.enabled = SaturationEnabled.Value;
 
-            if (_bloomComponent != null)
-                _bloomComponent.bloomIntensity = bloomPower;
+            if (_bloomComponent != null && OverrideBloomStrength.Value)
+                _bloomComponent.bloomIntensity = BloomStrength.Value;
         }
 
         private IEnumerator DelayMethod(Action action)
@@ -73,6 +76,6 @@ namespace ColorCorrector
             action();
         }
 
-        private void OnSettingChanged(object sender, System.EventArgs e) => SetEffects(SaturationEnabled.Value, BloomStrength.Value);
+        private void OnSettingChanged(object sender, System.EventArgs e) => SetEffects();
     }
 }


### PR DESCRIPTION
This makes the plugin effectively no-op with the default settings.

Note that this is a breaking change for users who do use the override. I briefly looked for a way to keep the override enabled when the value has been changed from the default, but I couldn't find a nice way. I hope this isn't too much of a problem.