### PR TITLE
Loosening the check for gamename in the manifest with KK/KKS

### DIFF
--- a/src/KKS_Sideloader/KKS.Sideloader.cs
+++ b/src/KKS_Sideloader/KKS.Sideloader.cs
@@ -11,7 +11,7 @@ namespace Sideloader
     [BepInProcess(Constants.StudioProcessName)]
     public partial class Sideloader : BaseUnityPlugin
     {
-        internal static readonly string[] GameNameList = { "koikatsu sunshine", "koikatu sunshine", "コイカツ sunshine" };
+        internal static readonly string[] GameNameList = { "koikatsu sunshine", "koikatu sunshine", "コイカツ sunshine", "koikatsu", "koikatu", "コイカツ" };
         
         private static string FindKoiZipmodDir()
         {

--- a/src/KK_Sideloader/KK.Sideloader.cs
+++ b/src/KK_Sideloader/KK.Sideloader.cs
@@ -11,7 +11,7 @@ namespace Sideloader
     [BepInIncompatibility("com.bepis.bepinex.resourceredirector")]
     public partial class Sideloader : BaseUnityPlugin
     {
-        internal static readonly string[] GameNameList = { "koikatsu", "koikatu", "コイカツ" };
+        internal static readonly string[] GameNameList = { "koikatsu", "koikatu", "コイカツ", "koikatsu sunshine", "koikatu sunshine", "コイカツ sunshine" };
 
         private static string FindKoiZipmodDir() => string.Empty;
     }


### PR DESCRIPTION
I wanted to save myself the work of rewriting the manifesto.
I don't think this is right. But I think it is better than users spending their time manually rewriting it or asking others about it.