### PR TITLE
[Screencap] StitchImages optimized

### DIFF
--- a/src/Core_Screencap/Core.ScreenshotManager.cs
+++ b/src/Core_Screencap/Core.ScreenshotManager.cs
@@ -486,16 +486,12 @@ namespace Screencap
         {
             var xAdjust = (int)(capture.width * overlapOffset);
             var result = new Texture2D((capture.width - xAdjust) * 2, capture.height, TextureFormat.ARGB32, false);
-            for (int x = 0; x < result.width; x++)
-            {
-                var first = x < result.width / 2;
-                var targetX = first ? x : x - capture.width + xAdjust * 2;
-                var targetTex = first ? capture : capture2;
-                for (int y = 0; y < result.height; y++)
-                {
-                    result.SetPixel(x, y, targetTex.GetPixel(targetX, y));
-                }
-            }
+
+            int width = result.width / 2;
+            int height = result.height;
+            result.SetPixels(0, 0, width, height, capture.GetPixels(0, 0, width, height));
+            result.SetPixels(width, 0, width, height, capture2.GetPixels(xAdjust, 0, width, height));
+
             result.Apply();
             return result;
         }


### PR DESCRIPTION
StitchImages has been optimized. 
Please merge it if there are no problems.

The processing time was measured using the code below, and the processing time that used to take 4 seconds was reduced to 0.5 seconds. Depending on the capture parameters, it can be sped up by a factor of 5 to 8.
```
Stopwatch watch = Stopwatch.StartNew();
var result = FlipEyesIn3DCapture.Value ? StitchImages(capture, capture2, 0) : StitchImages(capture2, capture, 0);
System.Console.WriteLine($"@@ {watch.ElapsedMilliseconds}");
```

There is no visible change.
Before:
![CharaStudio-2024-07-03-10-20-20-3D-360](https://github.com/IllusionMods/BepisPlugins/assets/4230203/d4e423c8-eb47-498d-b440-131f0c6f7b7b)

After:
![CharaStudio-2024-07-03-10-19-01-3D-360](https://github.com/IllusionMods/BepisPlugins/assets/4230203/37723f30-a916-449b-ae53-10c9a4e22f97)


I think it would be more than 10 times faster if the processing were completed entirely in VRAM, including the argument textures. However, additional VRAM would be required for the buffer.
I refrained from doing so because I knew that people would inevitably complain that they could no longer capture.

