### PR TITLE
[Screencap][AI/HS2] Port the tool window + related features from the KK branch

### DIFF
--- a/src/AIHS2_Core_Screencap/ScreenshotManager.cs
+++ b/src/AIHS2_Core_Screencap/ScreenshotManager.cs
@@ -28,6 +28,7 @@ namespace Screencap
     /// <summary>
     /// Plugin for taking high quality screenshots with optional transparency.
     /// Brought to AI-Shoujo by essu - the local smug, benevolent modder.
+    /// Tool Window ported from KK by SuitIThub
     /// Provides features like:
     /// - Custom resolution screenshots
     /// - Transparency support

--- a/src/AIHS2_Core_Screencap/ScreenshotManager.cs
+++ b/src/AIHS2_Core_Screencap/ScreenshotManager.cs
@@ -97,7 +97,6 @@ namespace Screencap
         /// </summary>
         private void InitializeSettings()
         {
-            Console.WriteLine("Initializing settings");
             ResolutionAllowExtreme = Config.Bind(
                 "Rendered screenshots", "Allow extreme resolutions",
                 false,
@@ -176,7 +175,7 @@ namespace Screencap
             SavedResolutionsConfig = Config.Bind(
                 "Rendered screenshots", "Saved Resolutions",
                 string.Empty,
-                new ConfigDescription("List of saved resolutions in JSON format.", null, "Debug"));
+                new ConfigDescription("List of saved resolutions in JSON format.", null, "Advanced"));
 
             LoadSavedResolutions();
         }
@@ -230,19 +229,16 @@ namespace Screencap
 
         private void Awake()
         {
-            Console.WriteLine("Awake");
             InitializeSettings();
 
             CaptureWidth.SettingChanged += (sender, args) => CaptureWidthBuffer = CaptureWidth.Value.ToString();
             CaptureHeight.SettingChanged += (sender, args) => CaptureHeightBuffer = CaptureHeight.Value.ToString();
 
-            Console.WriteLine("Loading assets");
             var ab = AssetBundle.LoadFromMemory(ResourceUtils.GetEmbeddedResource("composite.unity3d"));
             _matComposite = new Material(ab.LoadAsset<Shader>("composite"));
             _matScale = new Material(ab.LoadAsset<Shader>("resize"));
             ab.Unload(false);
 
-            Console.WriteLine("Applying hooks");
             Hooks.Apply();
         }
 
@@ -1018,9 +1014,9 @@ namespace Screencap
                 Process.Start(screenshotDir);
 
             GUILayout.Space(10);
-            if (GUILayout.Button("Capture Normal (F10)"))
+            if (GUILayout.Button($"Capture Normal ({KeyCaptureNormal.Value})"))
                 CaptureScreenshotNormal();
-            if (GUILayout.Button("Capture Render (F11)"))
+            if (GUILayout.Button($"Capture Render ({KeyCaptureRender.Value})"))
                 CaptureScreenshotRender();
 
             GUILayout.Space(2);


### PR DESCRIPTION
Completes Issue #210 

Introduces a red frame showing what area of the screen will be captured based on the values set in the screenshot manager.

Example on Screen with Resolution 2560 x 1440:
![image](https://github.com/user-attachments/assets/23e9ca4b-a137-4f8e-8893-951740c3d80c)
