### PR TITLE
[Screencap][AI/HS2] Fix "Images overlap when Press F11 quickly"

### DIFF
--- a/src/AIHS2_Core_Screencap/ScreenshotManager.cs
+++ b/src/AIHS2_Core_Screencap/ScreenshotManager.cs
@@ -277,7 +277,7 @@ namespace Screencap
             while (screenshotQueue.Count > 0)
             {
                 var coroutine = screenshotQueue.Dequeue();
-                yield return StartCoroutine(coroutine); // 🧠 중요: 완료될 때까지 기다림
+                yield return StartCoroutine(coroutine);
             }
 
             isProcessing = false;


### PR DESCRIPTION
- Fixed #212 
- changed screen capture actions in Update() to asynchronous way
  reason why: If video capture is performed in synchronous mode, the program occasionally freezes. Therefore, this process needs to be converted to a message-based asynchronous mode