### PR TITLE
[Sideloader] Bump SharpZipLib to 1.3.3, keep KK pinned for net35

### DIFF
--- a/src/AI_Sideloader/AI_Sideloader.csproj
+++ b/src/AI_Sideloader/AI_Sideloader.csproj
@@ -68,7 +68,7 @@
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
 
-		<PackageReference Include="SharpZipLib" Version="[1.0,1.4)" NoWarn="NU1904, NU1903, NU1902" />
+		<PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
 	</ItemGroup>
 
 	<Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/EC_Sideloader/EC_Sideloader.csproj
+++ b/src/EC_Sideloader/EC_Sideloader.csproj
@@ -68,7 +68,7 @@
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
 
-		<PackageReference Include="SharpZipLib" Version="[1.0,1.4)" NoWarn="NU1904, NU1903, NU1902" />
+		<PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
 	</ItemGroup>
 
 	<Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/HS2_Sideloader/HS2_Sideloader.csproj
+++ b/src/HS2_Sideloader/HS2_Sideloader.csproj
@@ -72,7 +72,7 @@
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
 
-		<PackageReference Include="SharpZipLib" Version="[1.0,1.4)" NoWarn="NU1904, NU1903, NU1902" />
+		<PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
 	</ItemGroup>
 
 	<Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/KKS_Sideloader/KKS_Sideloader.csproj
+++ b/src/KKS_Sideloader/KKS_Sideloader.csproj
@@ -68,7 +68,7 @@
 			<IncludeAssets>compile</IncludeAssets>
 		</PackageReference>
 
-		<PackageReference Include="SharpZipLib" Version="[1.0,1.4)" NoWarn="NU1904, NU1903, NU1902" />
+		<PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
 	</ItemGroup>
 
 	<Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/KK_Sideloader/KK_Sideloader.csproj
+++ b/src/KK_Sideloader/KK_Sideloader.csproj
@@ -53,7 +53,9 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 
-		<PackageReference Include="SharpZipLib" Version="[0.86.0,1.0)" NoWarn="NU1904, NU1903, NU1902" />
+		<!-- Pinned to 0.86.0: net35 can't use SharpZipLib 1.x (needs net45+), and no patched net35 build exists.
+		     CVEs are in extract to disk helpers which Sideloader never calls, so this is safe. -->
+		<PackageReference Include="SharpZipLib" Version="[0.86.0,1.0)" NoWarn="NU1903, NU1902" />
 	</ItemGroup>
 
 	<Import Project="..\Shared\Shared.projitems" Label="Shared" />


### PR DESCRIPTION
## Description
Bumping SharpZipLib version to 1.3.3 for all games besides KK to get rid of CVE warnings.
Also removed NU1904 from KK since the CVE is only high not critical.

## Motivation and Context
This is just a cleanup. We never used vulnerable functions so this was never a problem.

## How Has This Been Tested?
Loaded the games:
Successfully loaded 4410 mods out of 4437 in 3594ms
no errors 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
