### PR TITLE
[Screencap] Add optional filename prefix; Fix overwriting rapid fire screenshots

### DIFF
--- a/src/Core_Screencap/ScreenshotManager.cs
+++ b/src/Core_Screencap/ScreenshotManager.cs
@@ -238,6 +238,7 @@ namespace Screencap
         public static ConfigEntry<int> GuideLineThickness { get; private set; }
         public static ConfigEntry<NameFormat> ScreenshotNameFormat { get; private set; }
         public static ConfigEntry<string> ScreenshotNameOverride { get; private set; }
+        public static ConfigEntry<string> FilenamePrefix { get; private set; }
 
         public static ConfigEntry<KeyboardShortcut> KeyCapture360 { get; private set; }
         public static ConfigEntry<int> Resolution360 { get; private set; }
@@ -314,6 +315,11 @@ namespace Screencap
                 "General", "Screenshot filename Name override",
                 "",
                 new ConfigDescription("Forces the Name part of the filename to always be this instead of varying depending on the name of the current game. Use \"Koikatsu\" to get the old filename behaviour.", null, "Advanced"));
+
+            FilenamePrefix = Config.Bind(
+                "General", "Filename prefix",
+                "",
+                new ConfigDescription("Optional text prepended to screenshot filenames. Handy as a per-scene tag (e.g. \"outfit1_pose1\") to keep captures sorted. Editable in the quick access settings window. Leave empty to disable."));
 
             GuideLinesModes = Config.Bind(
                 "General", "Camera guide lines",
@@ -486,6 +492,14 @@ namespace Screencap
 
             var extension = useJpg ? "jpg" : "png";
 
+            var prefix = FilenamePrefix.Value;
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                foreach (var c in Path.GetInvalidFileNameChars())
+                    prefix = prefix.Replace(c, '_');
+                prefix += "-";
+            }
+
             // Legacy AI/HS2 filenames
             // $"AI_{DateTime.Now:yyyy-MM-dd-HH-mm-ss-fff}.png"
             // $"HS2_{DateTime.Now:yyyy-MM-dd-HH-mm-ss-fff}.png"
@@ -514,7 +528,7 @@ namespace Screencap
                     throw new ArgumentOutOfRangeException("Unhandled screenshot filename format - " + ScreenshotNameFormat.Value);
             }
 
-            return Path.GetFullPath(Path.Combine(ScreenshotDir, filename));
+            return Path.GetFullPath(Path.Combine(ScreenshotDir, prefix + filename));
         }
 
         private static IEnumerator TakeUIScreenshot()
@@ -599,6 +613,14 @@ namespace Screencap
                     textColor = Color.white
                 }
             };
+
+            // Scene name section
+            GUILayout.BeginVertical(GUI.skin.box);
+            {
+                GUILayout.Label("Filename prefix", titleStyle);
+                FilenamePrefix.Value = GUILayout.TextField(FilenamePrefix.Value);
+            }
+            GUILayout.EndVertical();
 
             // Resolution settings section
             GUILayout.BeginVertical(GUI.skin.box);

--- a/src/Core_Screencap/ScreenshotManager.cs
+++ b/src/Core_Screencap/ScreenshotManager.cs
@@ -320,6 +320,13 @@ namespace Screencap
                 "General", "Filename prefix",
                 "",
                 new ConfigDescription("Optional text prepended to screenshot filenames. Handy as a per-scene tag (e.g. \"outfit1_pose1\") to keep captures sorted. Editable in the quick access settings window. Leave empty to disable."));
+            FilenamePrefix.SettingChanged += (s, e) =>
+            {
+                var sanitized = FilenamePrefix.Value;
+                foreach (var c in Path.GetInvalidFileNameChars())
+                    sanitized = sanitized.Replace(c, '_');
+                if (sanitized != FilenamePrefix.Value) FilenamePrefix.Value = sanitized;
+            };
 
             GuideLinesModes = Config.Bind(
                 "General", "Camera guide lines",
@@ -484,6 +491,8 @@ namespace Screencap
 
         #region Capture methods
 
+        private static string _lastCaptureFilename;
+
         private static string GetUniqueFilename(string capType, bool useJpg)
         {
             var productName = !string.IsNullOrEmpty(ScreenshotNameOverride.Value)
@@ -494,11 +503,10 @@ namespace Screencap
 
             var prefix = FilenamePrefix.Value;
             if (!string.IsNullOrEmpty(prefix))
-            {
-                foreach (var c in Path.GetInvalidFileNameChars())
-                    prefix = prefix.Replace(c, '_');
                 prefix += "-";
-            }
+
+            var now = DateTime.Now;
+            var date = now.ToString("yyyy-MM-dd_HH-mm-ss");
 
             // Legacy AI/HS2 filenames
             // $"AI_{DateTime.Now:yyyy-MM-dd-HH-mm-ss-fff}.png"
@@ -507,28 +515,35 @@ namespace Screencap
             switch (ScreenshotNameFormat.Value)
             {
                 case NameFormat.NameDate:
-                    filename = $"{productName}-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.{extension}";
+                    filename = $"{productName}-{date}.{extension}";
                     break;
                 case NameFormat.NameTypeDate:
-                    filename = $"{productName}-{capType}-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.{extension}";
+                    filename = $"{productName}-{capType}-{date}.{extension}";
                     break;
                 case NameFormat.NameDateType:
-                    filename = $"{productName}-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}-{capType}.{extension}";
+                    filename = $"{productName}-{date}-{capType}.{extension}";
                     break;
                 case NameFormat.TypeDate:
-                    filename = $"{capType}-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.{extension}";
+                    filename = $"{capType}-{date}.{extension}";
                     break;
                 case NameFormat.TypeNameDate:
-                    filename = $"{capType}-{productName}-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.{extension}";
+                    filename = $"{capType}-{productName}-{date}.{extension}";
                     break;
                 case NameFormat.Date:
-                    filename = $"{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.{extension}";
+                    filename = $"{date}.{extension}";
                     break;
                 default:
                     throw new ArgumentOutOfRangeException("Unhandled screenshot filename format - " + ScreenshotNameFormat.Value);
             }
 
-            return Path.GetFullPath(Path.Combine(ScreenshotDir, prefix + filename));
+            var basePath = Path.GetFullPath(Path.Combine(ScreenshotDir, prefix + filename));
+
+            var fullPath = basePath == _lastCaptureFilename
+                ? basePath.Substring(0, basePath.Length - extension.Length - 1) + "_" + now.ToString("fff") + "." + extension
+                : basePath;
+            _lastCaptureFilename = basePath;
+
+            return fullPath;
         }
 
         private static IEnumerator TakeUIScreenshot()

--- a/src/Core_Screencap_KKEC/ScreenshotManager.KKEC.cs
+++ b/src/Core_Screencap_KKEC/ScreenshotManager.KKEC.cs
@@ -109,7 +109,7 @@ namespace Screencap
                 var t2d = result.CopyToTexture2D();
                 RenderTexture.ReleaseTemporary(result);
                 yield return null;
-                var px = t2d.GetPixels();
+                var px = t2d.GetPixels32();
                 GameObject.DestroyImmediate(t2d);
 #else
                 var req = UnityEngine.Rendering.AsyncGPUReadback.Request(result, 0, 0, result.width, 0, result.height, 0, 1, TextureFormat.RGBA32);

--- a/src/Core_Screencap_KKEC/ScreenshotManager.KKEC.cs
+++ b/src/Core_Screencap_KKEC/ScreenshotManager.KKEC.cs
@@ -109,7 +109,7 @@ namespace Screencap
                 var t2d = result.CopyToTexture2D();
                 RenderTexture.ReleaseTemporary(result);
                 yield return null;
-                var px = t2d.GetPixels32();
+                var px = t2d.GetPixels();
                 GameObject.DestroyImmediate(t2d);
 #else
                 var req = UnityEngine.Rendering.AsyncGPUReadback.Request(result, 0, 0, result.width, 0, result.height, 0, 1, TextureFormat.RGBA32);


### PR DESCRIPTION
<!--- If your change only affects some games or only one plugin out of multiple, 
      put this information in the title, e.g. "[ME][KK/KKS] Add a kitchen sink"-->

## Description
Implements request #239 
Fixes name collision from #236 

Slowdown of #235 could not be replicated (20.1 was in testing slower than latest)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested ingame if prefixs get set and an unset prefix results in before change filenames.

## Screenshots (if appropriate):
<img width="815" height="817" alt="image" src="https://github.com/user-attachments/assets/4e0cfb71-6d4e-4756-b794-bdc55115e4b6" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
